### PR TITLE
Expand test mode

### DIFF
--- a/Core/Inc/data_store.h
+++ b/Core/Inc/data_store.h
@@ -50,10 +50,10 @@ private:
 
     static data_store *p_instance_;
     
-    uint32_t rpm_       = 0;
-    uint32_t tps_       = 0;
-    uint32_t gndspd_    = 0;
-    uint32_t engtmp_    = 0;
+    uint32_t rpm_       = 12345;
+    uint32_t tps_       = 50;
+    uint32_t gndspd_    = 60;
+    uint32_t engtmp_    = 80;
     uint32_t inltmp_    = 0;
     uint32_t gear_      = 0;
     uint32_t lambda_    = 0;

--- a/Core/Inc/data_store.h
+++ b/Core/Inc/data_store.h
@@ -50,21 +50,16 @@ private:
 
     static data_store *p_instance_;
     
-    //#TODO: maybe make rpm_ an int
-    uint32_t rpm_ = 0;
-    uint32_t tps_ = 0.0;
-    uint32_t gndspd_ = 0.0;
-    uint32_t engtmp_ = 0.0;
-    uint32_t inltmp_ = 0.0;
-    uint32_t gear_ = 1;
-    uint32_t lambda_ = 0.0;
-    uint32_t map_ = 0.0;
-    uint32_t bap_ = 0.0;
-    uint32_t batt_ = 0.0;
-    
-
-
-    uint32_t test = 0;
+    uint32_t rpm_       = 0;
+    uint32_t tps_       = 0;
+    uint32_t gndspd_    = 0;
+    uint32_t engtmp_    = 0;
+    uint32_t inltmp_    = 0;
+    uint32_t gear_      = 0;
+    uint32_t lambda_    = 0;
+    uint32_t map_       = 0;
+    uint32_t bap_       = 0;
+    uint32_t batt_      = 0;
 };
 
 #endif

--- a/Core/Inc/data_store.h
+++ b/Core/Inc/data_store.h
@@ -15,51 +15,51 @@ public:
         return p_instance_;
     }
 
-    void set_rpm(uint32_t rpm) { rpm_ = rpm; }
-    uint32_t get_rpm() { return rpm_; }
+    void set_rpm(uint16_t rpm) { rpm_ = rpm; }
+    uint16_t get_rpm() { return rpm_; }
 
-    void set_tps(uint32_t tps) { tps_ = tps; }
-    uint32_t get_tps() { return tps_; }
+    void set_tps(uint16_t tps) { tps_ = tps; }
+    uint16_t get_tps() { return tps_; }
 
-    void set_gndspd(uint32_t gndspd) { gndspd_ = gndspd; }
-    uint32_t get_gndspd() { return gndspd_; }
+    void set_gndspd(uint16_t gndspd) { gndspd_ = gndspd; }
+    uint16_t get_gndspd() { return gndspd_; }
 
-    void set_engtmp(uint32_t engtmp) { engtmp_ = engtmp; }
-    uint32_t get_engtmp() { return engtmp_; }
+    void set_engtmp(uint16_t engtmp) { engtmp_ = engtmp; }
+    uint16_t get_engtmp() { return engtmp_; }
 
-    void set_inltmp(uint32_t inltmp) { inltmp_ = inltmp; }
-    uint32_t get_inltmp() { return inltmp_; }
+    void set_inltmp(uint16_t inltmp) { inltmp_ = inltmp; }
+    uint16_t get_inltmp() { return inltmp_; }
 
-    void set_gear(uint32_t gear) { gear_ = gear; }
-    uint32_t get_gear() { return gear_; }
+    void set_gear(uint16_t gear) { gear_ = gear; }
+    uint16_t get_gear() { return gear_; }
 
-    void set_lambda(uint32_t lambda) { lambda_ = lambda; }
-    uint32_t get_lambda() { return lambda_; }
+    void set_lambda(uint16_t lambda) { lambda_ = lambda; }
+    uint16_t get_lambda() { return lambda_; }
 
-    void set_map(uint32_t map) { map_ = map; }
-    uint32_t get_map() { return map_; }
+    void set_map(uint16_t map) { map_ = map; }
+    uint16_t get_map() { return map_; }
 
-    void set_bap(uint32_t bap) { bap_ = bap; }
-    uint32_t get_bap() { return bap_; }
+    void set_bap(uint16_t bap) { bap_ = bap; }
+    uint16_t get_bap() { return bap_; }
 
-    void set_batt(uint32_t batt) { batt_ = batt; }
-    uint32_t get_batt() { return batt_; }
+    void set_batt(uint16_t batt) { batt_ = batt; }
+    uint16_t get_batt() { return batt_; }
 
 private:
     data_store() { /* Default Constructor */ }
 
     static data_store *p_instance_;
     
-    uint32_t rpm_       = 0;
-    uint32_t tps_       = 0;
-    uint32_t gndspd_    = 0;
-    uint32_t engtmp_    = 0;
-    uint32_t inltmp_    = 0;
-    uint32_t gear_      = 0;
-    uint32_t lambda_    = 0;
-    uint32_t map_       = 0;
-    uint32_t bap_       = 0;
-    uint32_t batt_      = 0;
+    uint16_t rpm_       = 0;
+    uint16_t tps_       = 0;
+    uint16_t gndspd_    = 0;
+    uint16_t engtmp_    = 0;
+    uint16_t inltmp_    = 0;
+    uint16_t gear_      = 0;
+    uint16_t lambda_    = 0;
+    uint16_t map_       = 0;
+    uint16_t bap_       = 0;
+    uint16_t batt_      = 0;
 };
 
 #endif

--- a/Core/Inc/data_store.h
+++ b/Core/Inc/data_store.h
@@ -50,10 +50,10 @@ private:
 
     static data_store *p_instance_;
     
-    uint32_t rpm_       = 12345;
-    uint32_t tps_       = 50;
-    uint32_t gndspd_    = 60;
-    uint32_t engtmp_    = 80;
+    uint32_t rpm_       = 0;
+    uint32_t tps_       = 0;
+    uint32_t gndspd_    = 0;
+    uint32_t engtmp_    = 0;
     uint32_t inltmp_    = 0;
     uint32_t gear_      = 0;
     uint32_t lambda_    = 0;

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -18,11 +18,22 @@ public:
     bool get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
 
 private:
-    test_mode() { /* Intentionally empty */ }
+    uint8_t MESSAGE_BURST_COUNT = 2;
+    uint8_t MESSAGE_BURST_DELAY = 1;
+
+    test_mode() 
+    {
+        burst_active_ = true;
+        burst_count_ = 0;
+    }
 
     static test_mode *p_instance_;
 
     test_mode *p_test_mode_ = nullptr;
+
+    bool burst_active_;
+
+    uint8_t burst_count_;
 };
 
 #endif

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -32,9 +32,14 @@ private:
         burst_count_ = 0;
     }
 
-    void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
+    void can_data_pack(uint16_t store_data, uint8_t *p_data)
+    {
+        *p_data = store_data >> 8;
+        ++p_data;
+        *p_data = store_data;
+    }
 
-    void can_data_pack(uint16_t store_data, uint8_t *p_data);
+    void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
 
     static test_mode *p_instance_;
 

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -24,6 +24,14 @@ private:
     uint8_t MESSAGE_BURST_COUNT = 2;
     uint8_t MESSAGE_BURST_DELAY = 1;
 
+    static test_mode *p_instance_;
+
+    test_mode *p_test_mode_ = nullptr;
+    data_store *p_data_store_ = nullptr;
+
+    bool burst_active_;
+    uint8_t burst_count_;
+
     test_mode() 
     {
         p_data_store_ = data_store::instance();
@@ -40,16 +48,6 @@ private:
     }
 
     void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
-
-    static test_mode *p_instance_;
-
-    test_mode *p_test_mode_ = nullptr;
-
-    data_store *p_data_store_ = nullptr;
-
-    bool burst_active_;
-
-    uint8_t burst_count_;
 };
 
 #endif

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -34,7 +34,7 @@ private:
 
     void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
 
-    void can_data_pack(uint32_t store_data, uint8_t *p_data);
+    void can_data_pack(uint16_t store_data, uint8_t *p_data);
 
     static test_mode *p_instance_;
 

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -34,7 +34,7 @@ private:
 
     void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
 
-    void data_store_pack(uint32_t store_data, uint8_t *p_data);
+    void can_data_pack(uint32_t store_data, uint8_t *p_data);
 
     static test_mode *p_instance_;
 

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -3,6 +3,8 @@
 #ifndef TEST_MODE_H
 #define TEST_MODE_H
 
+#include <stdint.h>
+
 #include "stm32f4xx_hal.h"
 #include "data_store.h"
 
@@ -31,6 +33,8 @@ private:
     }
 
     void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
+
+    void data_store_pack(uint32_t store_data, uint8_t *p_data);
 
     static test_mode *p_instance_;
 

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -1,0 +1,28 @@
+// test_mode.h
+
+#ifndef TEST_MODE_H
+#define TEST_MODE_H
+
+#include "stm32f4xx_hal.h"
+
+class test_mode 
+{
+public:
+    static test_mode *instance()
+    {
+        if (nullptr == p_instance_) { p_instance_ = new test_mode(); }
+
+        return p_instance_;
+    }
+
+    bool get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
+
+private:
+    test_mode() { /* Intentionally empty */ }
+
+    static test_mode *p_instance_;
+
+    test_mode *p_test_mode_ = nullptr;
+};
+
+#endif

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -4,6 +4,7 @@
 #define TEST_MODE_H
 
 #include "stm32f4xx_hal.h"
+#include "data_store.h"
 
 class test_mode 
 {
@@ -23,13 +24,19 @@ private:
 
     test_mode() 
     {
+        p_data_store_ = data_store::instance();
+
         burst_active_ = true;
         burst_count_ = 0;
     }
 
+    void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
+
     static test_mode *p_instance_;
 
     test_mode *p_test_mode_ = nullptr;
+
+    data_store *p_data_store_ = nullptr;
 
     bool burst_active_;
 

--- a/Core/Inc/test_mode.h
+++ b/Core/Inc/test_mode.h
@@ -21,8 +21,10 @@ public:
     bool get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
 
 private:
-    uint8_t MESSAGE_BURST_COUNT = 2;
-    uint8_t MESSAGE_BURST_DELAY = 1;
+    static const uint8_t MESSAGE_BURST_COUNT = 3;
+    static const uint8_t MESSAGE_BURST_DELAY = 1;
+
+    const uint32_t MESSAGE_LIST[MESSAGE_BURST_COUNT] = {0x5F0, 0x5F1, 0x5F2};
 
     static test_mode *p_instance_;
 
@@ -47,7 +49,7 @@ private:
         *p_data = store_data;
     }
 
-    void populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[]);
+    void populate_message(uint32_t id, uint8_t data[]);
 };
 
 #endif

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -2,7 +2,7 @@
 #include "can_parser.h"
 #include "test_mode.h".
 
-#define TEST_MODE // Uncomment when test mode is desired.
+//#define TEST_MODE // Uncomment when test mode is desired.
 
 #ifdef __cplusplus
 extern "C" {

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -14,11 +14,12 @@ extern "C" {
 /// @param hcan Pointer to the desired CAN peripheral's handler.
 void application_main(void *arg, CAN_HandleTypeDef *hcan)
 {
-    can_parser *p_can_parser = can_parser::instance(); ///< Pointer to the instance of can_parser.
-    test_mode *p_test_mode = test_mode::instance();    ///< Pointer to the instance of test_mode.
-
     CAN_RxHeaderTypeDef   rxHeader;  ///< Incoming CAN message header info.
     uint8_t               rxData[8]; ///< Incoming CAN message data bytes.
+
+    data_store *p_data_store = data_store::instance();  ///< Pointer to data_store instance.
+    can_parser *p_can_parser = can_parser::instance();  ///< Pointer to can_parser instance.
+    test_mode  *p_test_mode = test_mode::instance();    ///< Pointer to test_mode instance..
 
     // Begin infinite "main" loop of program. Execution is not intended to move beyond this.
     while (true) 
@@ -42,37 +43,20 @@ void application_main(void *arg, CAN_HandleTypeDef *hcan)
         // Provide a 1ms sleep to limit the MCU from running as fast as possible. 
         HAL_Delay(1);
 
-// shift light functionality evaluated each loop
-        //  When RPM is greater than 8000, turn on the blue light
-        if (8000 <= (data_store::instance()->get_rpm())) {
-            HAL_GPIO_WritePin (GPIOG, GPIO_PIN_13, GPIO_PIN_SET);
-        } else {
-            HAL_GPIO_WritePin (GPIOG, GPIO_PIN_13, GPIO_PIN_RESET);
-            }
+        // Shift light functionality evaluated each loop.
+        uint32_t rpm = p_data_store->get_rpm();
 
-        //  When RPM is greater than 11000, turn on the green light
-        if (11000 <= (data_store::instance()->get_rpm())) {
-            HAL_GPIO_WritePin (GPIOG, GPIO_PIN_11, GPIO_PIN_SET);
-        } else {
-            HAL_GPIO_WritePin (GPIOG, GPIO_PIN_11, GPIO_PIN_RESET);
-            }
+        //  When RPM is greater than 8000, turn on the blue light
+        HAL_GPIO_WritePin (GPIOG, GPIO_PIN_13, 8000 <= rpm ? GPIO_PIN_SET : GPIO_PIN_RESET);
+
+        //  When RPM is greater than 11000, turn on the other blue light
+        HAL_GPIO_WritePin (GPIOG, GPIO_PIN_11, 11000 <= rpm ? GPIO_PIN_SET : GPIO_PIN_RESET);
 
         //  When RPM is greater than 13000, turn on the yellow light
-        if (13000 <= (data_store::instance()->get_rpm())) {
-            HAL_GPIO_WritePin (GPIOG, GPIO_PIN_10, GPIO_PIN_SET);
-        } else {
-            HAL_GPIO_WritePin (GPIOG, GPIO_PIN_10, GPIO_PIN_RESET);
-            }
+        HAL_GPIO_WritePin (GPIOG, GPIO_PIN_10, 13000 <= rpm ? GPIO_PIN_SET : GPIO_PIN_RESET);
 
         //  When RPM is greater than 14000, turn on the orange light
-        if (14000 <= (data_store::instance()->get_rpm())) {
-            HAL_GPIO_WritePin (GPIOB, GPIO_PIN_1, GPIO_PIN_SET);
-        } else {
-            HAL_GPIO_WritePin (GPIOB, GPIO_PIN_1, GPIO_PIN_RESET);
-            }
-            
-        
-        
+        HAL_GPIO_WritePin (GPIOG, GPIO_PIN_1, 14000 <= rpm ? GPIO_PIN_SET : GPIO_PIN_RESET);
     }
 }
 

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -1,5 +1,6 @@
 #include "stm32f4xx_hal.h"
 #include "can_parser.h"
+#include "test_mode.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,6 +15,7 @@ extern "C" {
 void application_main(void *arg, CAN_HandleTypeDef *hcan)
 {
     can_parser *p_can_parser = can_parser::instance(); ///< Pointer to the instance of can_parser.
+    test_mode *p_test_mode = test_mode::instance();    ///< Pointer to the instance of test_mode.
 
     CAN_RxHeaderTypeDef   rxHeader;  ///< Incoming CAN message header info.
     uint8_t               rxData[8]; ///< Incoming CAN message data bytes.

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -2,7 +2,7 @@
 #include "can_parser.h"
 #include "test_mode.h".
 
-//#define TEST_MODE // Uncomment when test mode is desired.
+#define TEST_MODE // Uncomment when test mode is desired.
 
 #ifdef __cplusplus
 extern "C" {

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -40,7 +40,7 @@ void application_main(void *arg, CAN_HandleTypeDef *hcan)
         }
         #endif
 
-        // Shift light functionality evaluated each loop.
+        // Shift light functionality evaluated each loop. Cache the rpm from the data store prior to processing.
         uint32_t rpm = p_data_store->get_rpm();
 
         //  When RPM is greater than 8000, turn on the blue light

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -40,9 +40,6 @@ void application_main(void *arg, CAN_HandleTypeDef *hcan)
         }
         #endif
 
-        // Provide a 1ms sleep to limit the MCU from running as fast as possible. 
-        HAL_Delay(1);
-
         // Shift light functionality evaluated each loop.
         uint32_t rpm = p_data_store->get_rpm();
 
@@ -57,6 +54,9 @@ void application_main(void *arg, CAN_HandleTypeDef *hcan)
 
         //  When RPM is greater than 14000, turn on the orange light
         HAL_GPIO_WritePin (GPIOG, GPIO_PIN_1, 14000 <= rpm ? GPIO_PIN_SET : GPIO_PIN_RESET);
+
+        // Provide a 1ms sleep to limit the MCU from running as fast as possible. 
+        HAL_Delay(1);
     }
 }
 

--- a/Core/Src/application_main.cpp
+++ b/Core/Src/application_main.cpp
@@ -1,11 +1,8 @@
-//#define TEST_MODE
-
 #include "stm32f4xx_hal.h"
 #include "can_parser.h"
-
-#ifdef TEST_MODE
 #include "test_mode.h".
-#endif
+
+//#define TEST_MODE // Uncomment when test mode is desired.
 
 #ifdef __cplusplus
 extern "C" {

--- a/Core/Src/can_parser.cpp
+++ b/Core/Src/can_parser.cpp
@@ -10,7 +10,6 @@ void can_parser::process(uint32_t id, uint8_t data[])
     {
         case 0x5F0:
             // RPM, Throttle Position, Ground Speed, Engine Temp
-            // Endianness is probably wrong, but it's a start.
             p_data_store_->set_rpm((uint32_t)(data[1] | (data[0] << 8)));
             p_data_store_->set_tps((uint32_t)(data[3] | (data[2] << 8)));
             p_data_store_->set_gndspd((uint32_t)(data[5] | (data[4] << 8)));

--- a/Core/Src/can_parser.cpp
+++ b/Core/Src/can_parser.cpp
@@ -10,22 +10,22 @@ void can_parser::process(uint32_t id, uint8_t data[])
     {
         case 0x5F0:
             // RPM, Throttle Position, Ground Speed, Engine Temp
-            p_data_store_->set_rpm((uint32_t)(data[1] | (data[0] << 8)));
-            p_data_store_->set_tps((uint32_t)(data[3] | (data[2] << 8)));
-            p_data_store_->set_gndspd((uint32_t)(data[5] | (data[4] << 8)));
-            p_data_store_->set_engtmp((uint32_t)(data[7] | (data[6] << 8)));
+            p_data_store_->set_rpm((uint16_t)(data[1] | (data[0] << 8)));
+            p_data_store_->set_tps((uint16_t)(data[3] | (data[2] << 8)));
+            p_data_store_->set_gndspd((uint16_t)(data[5] | (data[4] << 8)));
+            p_data_store_->set_engtmp((uint16_t)(data[7] | (data[6] << 8)));
             break;
         case 0x5F1:
             // Inlet Air Temp, Gear, Lambda 1, MAP
-            // p_data_store_->set_inltmp((uint32_t)(data[1] | (data[0] << 8)));
-            p_data_store_->set_gear((uint32_t)(data[3] | (data[2] << 8)));
-            p_data_store_->set_lambda((uint32_t)(data[5] | (data[4] << 8)));
-            // p_data_store_->set_map((uint32_t)(data[7] | (data[6] << 8)));
+            // p_data_store_->set_inltmp((uint16_t)(data[1] | (data[0] << 8)));
+            p_data_store_->set_gear((uint16_t)(data[3] | (data[2] << 8)));
+            p_data_store_->set_lambda((uint16_t)(data[5] | (data[4] << 8)));
+            // p_data_store_->set_map((uint16_t)(data[7] | (data[6] << 8)));
             break;
         case 0x5F2:
             // BAP, Batt Voltage
-            // p_data_store_->set_bap((uint32_t)(data[1] | (data[0] << 8)));
-            p_data_store_->set_batt((uint32_t)(data[3] | (data[2] << 8)));
+            // p_data_store_->set_bap((uint16_t)(data[1] | (data[0] << 8)));
+            p_data_store_->set_batt((uint16_t)(data[3] | (data[2] << 8)));
             break;
         default:
             // Do nothing.

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -42,7 +42,10 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
     pHeader->StdId = 0x5F0;
 
-    uint32_t temp = p_data_store_->get_rpm();
+    data_store_pack(p_data_store_->get_rpm() + 1, &data[0]);
+
+
+    /*uint32_t temp = p_data_store_->get_rpm();
     data[0] = temp >> 8;
     data[1] = temp;
 
@@ -57,4 +60,10 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     temp = p_data_store_->get_engtmp();
     data[6] = temp >> 8;
     data[7] = temp;
+    */
+}
+
+void test_mode::data_store_pack(uint32_t store_data, uint8_t *p_data)
+{
+
 }

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -6,5 +6,36 @@ test_mode *test_mode::p_instance_ = nullptr;
 
 bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
-    return false;
+    ///@todo Clean this up, time permitting.
+    if (burst_active_)
+    {
+        if (MESSAGE_BURST_COUNT > burst_count_)
+        {
+            pHeader->StdId = 0x5F0;
+            data[0] = 0x12;
+            data[1] = 0x34;
+            burst_count_++;
+            return true;
+        }
+        else
+        {
+            burst_active_ = false;
+            burst_count_ = 0;
+            return get_rx_message(pHeader, data);
+        }
+    }
+    else
+    {
+        if (MESSAGE_BURST_DELAY > burst_count_)
+        {
+            return false;
+            burst_count_++;
+        }
+        else
+        {
+            burst_active_ = true;
+            burst_count_ = 0;
+            return get_rx_message(pHeader, data);
+        }
+    }
 }

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -48,7 +48,7 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     can_data_pack(p_data_store_->get_engtmp() + 1,  &data[6]);
 }
 
-void test_mode::can_data_pack(uint32_t store_data, uint8_t *p_data)
+void test_mode::can_data_pack(uint16_t store_data, uint8_t *p_data)
 {
     *p_data = store_data >> 8;
     ++p_data;

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -47,10 +47,3 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     can_data_pack(p_data_store_->get_gndspd() + 1,  &data[4]);
     can_data_pack(p_data_store_->get_engtmp() + 1,  &data[6]);
 }
-
-void test_mode::can_data_pack(uint16_t store_data, uint8_t *p_data)
-{
-    *p_data = store_data >> 8;
-    ++p_data;
-    *p_data = store_data;
-}

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -1,0 +1,10 @@
+// test_mode.cpp
+
+#include "test_mode.h"
+
+test_mode *test_mode::p_instance_ = nullptr;
+
+bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
+{
+    return false;
+}

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -28,23 +28,39 @@ bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 
 void test_mode::populate_message(uint32_t id, uint8_t data[])
 {
+    uint16_t data_a = 0x0000;
+    uint16_t data_b = 0x0000;
+    uint16_t data_c = 0x0000;
+    uint16_t data_d = 0x0000;
+
     switch(id)
     {
         case 0x5F0:
-            can_data_pack(p_data_store_->get_rpm() + 1,     &data[0]);
-            can_data_pack(p_data_store_->get_tps() + 1,     &data[2]);
-            can_data_pack(p_data_store_->get_gndspd() + 1,  &data[4]);
-            can_data_pack(p_data_store_->get_engtmp() + 1,  &data[6]);
+            data_a = p_data_store_->get_rpm();
+            data_b = p_data_store_->get_tps();
+            data_c = p_data_store_->get_gndspd();
+            data_d = p_data_store_->get_engtmp();
         break;
 
         case 0x5F1:
+            data_a = p_data_store_->get_inltmp();
+            data_b = p_data_store_->get_gear();
+            data_c = p_data_store_->get_lambda();
+            data_d = p_data_store_->get_map();
         break;
 
         case 0x5F2:
+            data_a = p_data_store_->get_bap();
+            data_b = p_data_store_->get_batt();
         break;
 
         default:
             // Do nothing.
         break;
     }
+
+    can_data_pack(++data_a, &data[0]);
+    can_data_pack(++data_b, &data[2]);
+    can_data_pack(++data_c, &data[4]);
+    can_data_pack(++data_d, &data[6]);
 }

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -11,9 +11,7 @@ bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     {
         if (MESSAGE_BURST_COUNT > burst_count_)
         {
-            pHeader->StdId = 0x5F0;
-            data[0] = 0x12;
-            data[1] = 0x34;
+            populate_message(pHeader, data);
             burst_count_++;
             return true;
         }
@@ -38,4 +36,25 @@ bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
             return get_rx_message(pHeader, data);
         }
     }
+}
+
+void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
+{
+    pHeader->StdId = 0x5F0;
+
+    uint32_t temp = p_data_store_->get_rpm();
+    data[0] = temp >> 8;
+    data[1] = temp;
+
+    temp = p_data_store_->get_tps();
+    data[2] = temp >> 8;
+    data[3] = temp;
+
+    temp = p_data_store_->get_gndspd();
+    data[4] = temp >> 8;
+    data[5] = temp;
+
+    temp = p_data_store_->get_engtmp();
+    data[6] = temp >> 8;
+    data[7] = temp;
 }

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -26,8 +26,8 @@ bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     {
         if (MESSAGE_BURST_DELAY > burst_count_)
         {
-            return false;
             burst_count_++;
+            return false;
         }
         else
         {
@@ -42,10 +42,10 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
     pHeader->StdId = 0x5F0;
 
-    can_data_pack(p_data_store_->get_rpm(), &data[0]);
-    can_data_pack(p_data_store_->get_tps(), &data[2]);
-    can_data_pack(p_data_store_->get_gndspd(), &data[4]);
-    can_data_pack(p_data_store_->get_engtmp(), &data[6]);
+    can_data_pack(p_data_store_->get_rpm() + 1,     &data[0]);
+    can_data_pack(p_data_store_->get_tps() + 1,     &data[2]);
+    can_data_pack(p_data_store_->get_gndspd() + 1,  &data[4]);
+    can_data_pack(p_data_store_->get_engtmp() + 1,  &data[6]);
 }
 
 void test_mode::can_data_pack(uint32_t store_data, uint8_t *p_data)

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -42,7 +42,7 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
     pHeader->StdId = 0x5F0;
 
-    data_store_pack(p_data_store_->get_rpm() + 1, &data[0]);
+    can_data_pack(p_data_store_->get_rpm() + 1, &data[0]);
 
 
     /*uint32_t temp = p_data_store_->get_rpm();
@@ -63,7 +63,7 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     */
 }
 
-void test_mode::data_store_pack(uint32_t store_data, uint8_t *p_data)
+void test_mode::can_data_pack(uint32_t store_data, uint8_t *p_data)
 {
 
 }

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -6,35 +6,22 @@ test_mode *test_mode::p_instance_ = nullptr;
 
 bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
-    ///@todo Clean this up, time permitting.
-    if (burst_active_)
+    if (burst_active_ && MESSAGE_BURST_COUNT > burst_count_)
     {
-        if (MESSAGE_BURST_COUNT > burst_count_)
-        {
-            populate_message(pHeader, data);
-            burst_count_++;
-            return true;
-        }
-        else
-        {
-            burst_active_ = false;
-            burst_count_ = 0;
-            return get_rx_message(pHeader, data);
-        }
+        populate_message(pHeader, data);
+        burst_count_++;
+        return true;
+    }
+    else if (!burst_active_ && MESSAGE_BURST_DELAY > burst_count_)
+    {
+        burst_count_++;
+        return false;
     }
     else
     {
-        if (MESSAGE_BURST_DELAY > burst_count_)
-        {
-            burst_count_++;
-            return false;
-        }
-        else
-        {
-            burst_active_ = true;
-            burst_count_ = 0;
-            return get_rx_message(pHeader, data);
-        }
+        burst_active_ = !burst_active_;
+        burst_count_ = 0;
+        return get_rx_message(pHeader, data);
     }
 }
 

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -8,7 +8,8 @@ bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
     if (burst_active_ && MESSAGE_BURST_COUNT > burst_count_)
     {
-        populate_message(pHeader, data);
+        pHeader->StdId = MESSAGE_LIST[burst_count_];
+        populate_message(pHeader->StdId, data);
         burst_count_++;
         return true;
     }
@@ -25,12 +26,25 @@ bool test_mode::get_rx_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
     }
 }
 
-void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
+void test_mode::populate_message(uint32_t id, uint8_t data[])
 {
-    pHeader->StdId = 0x5F0;
+    switch(id)
+    {
+        case 0x5F0:
+            can_data_pack(p_data_store_->get_rpm() + 1,     &data[0]);
+            can_data_pack(p_data_store_->get_tps() + 1,     &data[2]);
+            can_data_pack(p_data_store_->get_gndspd() + 1,  &data[4]);
+            can_data_pack(p_data_store_->get_engtmp() + 1,  &data[6]);
+        break;
 
-    can_data_pack(p_data_store_->get_rpm() + 1,     &data[0]);
-    can_data_pack(p_data_store_->get_tps() + 1,     &data[2]);
-    can_data_pack(p_data_store_->get_gndspd() + 1,  &data[4]);
-    can_data_pack(p_data_store_->get_engtmp() + 1,  &data[6]);
+        case 0x5F1:
+        break;
+
+        case 0x5F2:
+        break;
+
+        default:
+            // Do nothing.
+        break;
+    }
 }

--- a/Core/Src/test_mode.cpp
+++ b/Core/Src/test_mode.cpp
@@ -42,28 +42,15 @@ void test_mode::populate_message(CAN_RxHeaderTypeDef *pHeader, uint8_t data[])
 {
     pHeader->StdId = 0x5F0;
 
-    can_data_pack(p_data_store_->get_rpm() + 1, &data[0]);
-
-
-    /*uint32_t temp = p_data_store_->get_rpm();
-    data[0] = temp >> 8;
-    data[1] = temp;
-
-    temp = p_data_store_->get_tps();
-    data[2] = temp >> 8;
-    data[3] = temp;
-
-    temp = p_data_store_->get_gndspd();
-    data[4] = temp >> 8;
-    data[5] = temp;
-
-    temp = p_data_store_->get_engtmp();
-    data[6] = temp >> 8;
-    data[7] = temp;
-    */
+    can_data_pack(p_data_store_->get_rpm(), &data[0]);
+    can_data_pack(p_data_store_->get_tps(), &data[2]);
+    can_data_pack(p_data_store_->get_gndspd(), &data[4]);
+    can_data_pack(p_data_store_->get_engtmp(), &data[6]);
 }
 
 void test_mode::can_data_pack(uint32_t store_data, uint8_t *p_data)
 {
-
+    *p_data = store_data >> 8;
+    ++p_data;
+    *p_data = store_data;
 }

--- a/STM32CubeIDE/.cproject
+++ b/STM32CubeIDE/.cproject
@@ -1,316 +1,317 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
-	<storageModule moduleId="org.eclipse.cdt.core.settings">
-		<cconfiguration id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291" moduleId="org.eclipse.cdt.core.settings" name="Debug">
-				<externalSettings/>
-				<extensions>
-					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
-					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-				</extensions>
-			</storageModule>
-			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291" name="Debug" parent="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug">
-					<folderInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291." name="/" resourcePath="">
-						<toolChain id="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.debug.462329838" name="MCU ARM GCC" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.debug">
-							<option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.type.706982539" name="Internal Toolchain Type" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.type" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.version.288924887" name="Internal Toolchain Version" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.version" value="7-2018-q2-update" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu.1073988192" name="Mcu" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu" value="STM32F469NIHx" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid.1571270724" name="CpuId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid" value="0" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid.1462088936" name="CpuCoreId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid" value="0" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.1692964530" name="Floating-point unit" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.value.fpv4-sp-d16" valueType="enumerated"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.1789621614" name="Floating-point ABI" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.value.hard" valueType="enumerated"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board.1691071603" name="Board" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board" value="genericBoard" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults.1008652457" name="Defaults" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults" value="com.st.stm32cube.ide.common.services.build.inputs.revA.1.0.6 || Debug || true || Executable || com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32 || STM32F469NIHx || 0 || 0 || arm-none-eabi- || ${gnu_tools_for_stm32_compiler_path} || ../../Core/Inc | ../../Drivers/CMSIS/Include | ../../TouchGFX/target | ../../Drivers/CMSIS/Device/ST/STM32F4xx/Include | ../../TouchGFX/App | ../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 | ../../TouchGFX/target/generated | ../../Drivers/BSP/Components/Common | ../../Middlewares/Third_Party/FreeRTOS/Source/include | ../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy | ../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F | ../../Drivers/BSP/STM32469I-Discovery | ../../Drivers/STM32F4xx_HAL_Driver/Inc ||  ||  || USE_HAL_DRIVER | STM32F469xx ||  ||  ||  ||  || ${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld} || true || NonSecure ||  || secure_nsclib.o ||  || None ||  ||  || " valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" value="false" valueType="boolean"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" value="true" valueType="boolean"/>
-							<option id="com.st.stm32cube.ide.mcu.debug.option.cpuclock.12012555" superClass="com.st.stm32cube.ide.mcu.debug.option.cpuclock" value="180" valueType="string"/>
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform.1369289449" isAbstract="false" osList="all" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform"/>
-							<builder buildPath="${workspace_loc:/STM32F469I-DISCO-REV-AU1}/Debug" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder.1132458525" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.650711735" name="MCU GCC Assembler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.666566964" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g3" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.definedsymbols.1167365880" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.definedsymbols" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="DEBUG"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.459682850" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1847983586" name="MCU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.1774693180" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.925828807" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.value.os" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols.1102406246" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
-									<listOptionValue builtIn="false" value="USE_BPP=16"/>
-									<listOptionValue builtIn="false" value="STM32F469xx"/>
-									<listOptionValue builtIn="false" value="DEBUG"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.898654131" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="../../Core/Inc"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/App"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1036047372" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.584259652" name="MCU G++ Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.1578537529" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.1452145697" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.value.os" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols.496359161" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
-									<listOptionValue builtIn="false" value="STM32F469xx"/>
-									<listOptionValue builtIn="false" value="USE_BPP=16"/>
-									<listOptionValue builtIn="false" value="DEBUG"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths.866852851" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="../../Core/Inc"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/App"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.4365549957" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" valueType="stringList">
-									<listOptionValue builtIn="false" value="-femit-class-debug-always"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1112311442" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1071469684" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script.525469482" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.387270243" name="MCU G++ Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script.262239035" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries.0109175191" name="Libraries (-l)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries" valueType="libs">
-									<listOptionValue builtIn="false" value=":libtouchgfx-float-abi-hard.a"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories.0446552423" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories" valueType="libPaths">
-									<listOptionValue builtIn="false" value="C:/git/STM32F469-dk/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/git/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/TouchGFXProjects/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/TouchGFXProjects/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/disan/GIT/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input.1690517566" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input">
-									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
-									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
-								</inputType>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver.112720624" name="MCU GCC Archiver" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size.1021209896" name="MCU Size" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile.1930886220" name="MCU Output Converter list file" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex.784557934" name="MCU Output Converter Hex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary.2036444560" name="MCU Output Converter Binary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog.112706189" name="MCU Output Converter Verilog" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec.1800298625" name="MCU Output Converter Motorola S-rec" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec.765135988" name="MCU Output Converter Motorola S-rec with symbols" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec"/>
-						</toolChain>
-					</folderInfo>
-				</configuration>
-			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
-		</cconfiguration>
-		<cconfiguration id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005" moduleId="org.eclipse.cdt.core.settings" name="Release">
-				<externalSettings/>
-				<extensions>
-					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
-					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-				</extensions>
-			</storageModule>
-			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005" name="Release" parent="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release">
-					<folderInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005." name="/" resourcePath="">
-						<toolChain id="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.release.1994443951" name="MCU ARM GCC" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.release">
-							<option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.type.1070928818" name="Internal Toolchain Type" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.type" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.version.641964570" name="Internal Toolchain Version" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.version" value="7-2018-q2-update" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu.321322750" name="Mcu" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu" value="STM32F469NIHx" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid.1739227495" name="CpuId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid" value="0" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid.1613882270" name="CpuCoreId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid" value="0" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.348001976" name="Floating-point unit" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.value.fpv4-sp-d16" valueType="enumerated"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.151676201" name="Floating-point ABI" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.value.hard" valueType="enumerated"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board.1378726694" name="Board" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board" value="genericBoard" valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults.1547637504" name="Defaults" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults" value="com.st.stm32cube.ide.common.services.build.inputs.revA.1.0.6 || Release || false || Executable || com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32 || STM32F469NIHx || 0 || 0 || arm-none-eabi- || ${gnu_tools_for_stm32_compiler_path} || ../../Core/Inc | ../../Drivers/CMSIS/Include | ../../TouchGFX/target | ../../Drivers/CMSIS/Device/ST/STM32F4xx/Include | ../../TouchGFX/App | ../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 | ../../TouchGFX/target/generated | ../../Drivers/BSP/Components/Common | ../../Middlewares/Third_Party/FreeRTOS/Source/include | ../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy | ../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F | ../../Drivers/BSP/STM32469I-Discovery | ../../Drivers/STM32F4xx_HAL_Driver/Inc ||  ||  || USE_HAL_DRIVER | STM32F469xx ||  ||  ||  ||  || ${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld} || true || NonSecure ||  || secure_nsclib.o ||  || None ||  ||  || " valueType="string"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" value="false" valueType="boolean"/>
-							<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" value="true" valueType="boolean"/>
-							<option id="com.st.stm32cube.ide.mcu.debug.option.cpuclock.240469191" superClass="com.st.stm32cube.ide.mcu.debug.option.cpuclock" value="180" valueType="string"/>
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform.148438337" isAbstract="false" osList="all" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform"/>
-							<builder buildPath="${workspace_loc:/STM32F469I-DISCO-REV-AU1}/Release" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder.186794699" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.546809183" name="MCU GCC Assembler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.197735926" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g0" valueType="enumerated"/>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.857362494" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1892273616" name="MCU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.1781937296" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.value.g0" valueType="enumerated"/>
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.599489623" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.value.os" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols.569790826" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
-									<listOptionValue builtIn="false" value="USE_BPP=16"/>
-									<listOptionValue builtIn="false" value="STM32F469xx"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.1345921988" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="../../Core/Inc"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/App"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1751818057" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1548946496" name="MCU G++ Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.584413576" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.value.g0" valueType="enumerated"/>
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.1872327835" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.value.os" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols.780269013" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
-									<listOptionValue builtIn="false" value="USE_BPP=16"/>
-									<listOptionValue builtIn="false" value="STM32F469xx"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths.623536527" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="../../Core/Inc"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target"/>
-									<listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/App"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
-									<listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
-									<listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
-									<listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
-									<listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.2774206786" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" valueType="stringList">
-									<listOptionValue builtIn="false" value="-femit-class-debug-always"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.376917327" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1929512438" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script.997537656" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.1191782340" name="MCU G++ Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker">
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script.530279426" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries.6600641296" name="Libraries (-l)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries" valueType="libs">
-									<listOptionValue builtIn="false" value=":libtouchgfx-float-abi-hard.a"/>
-								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories.7485061840" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories" valueType="libPaths">
-									<listOptionValue builtIn="false" value="C:/git/STM32F469-dk/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/git/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/TouchGFXProjects/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/TouchGFXProjects/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/disan/GIT/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-									<listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
-								</option>
-								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input.129321398" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input">
-									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
-									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
-								</inputType>
-							</tool>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver.339128256" name="MCU GCC Archiver" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size.922199646" name="MCU Size" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile.183367632" name="MCU Output Converter list file" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex.1349177318" name="MCU Output Converter Hex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary.1446635427" name="MCU Output Converter Binary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog.1062307066" name="MCU Output Converter Verilog" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec.1957435828" name="MCU Output Converter Motorola S-rec" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec"/>
-							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec.1951891889" name="MCU Output Converter Motorola S-rec with symbols" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec"/>
-						</toolChain>
-					</folderInfo>
-				</configuration>
-			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
-		</cconfiguration>
-	</storageModule>
-	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-		<project id="STM32F469I-DISCO-REV-AU1.null.1960509173" name="STM32F469I-DISCO-REV-AU1"/>
-	</storageModule>
-	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
-	<storageModule moduleId="scannerConfiguration">
-		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		<scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1847983586;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1036047372">
-			<autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1892273616;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1751818057">
-			<autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.584259652;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1112311442">
-			<autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1548946496;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.376917327">
-			<autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
-	</storageModule>
-	<storageModule moduleId="refreshScope" versionNumber="2">
-		<configuration configurationName="Debug">
-			<resource resourceType="PROJECT" workspacePath="/STM32F469I-DISCO-REV-AU1"/>
-		</configuration>
-		<configuration configurationName="Release">
-			<resource resourceType="PROJECT" workspacePath="/STM32F469I-DISCO-REV-AU1"/>
-		</configuration>
-	</storageModule>
-	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+<?fileVersion 4.0.0?>
+<cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+  <storageModule moduleId="org.eclipse.cdt.core.settings">
+    <cconfiguration id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291">
+      <storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291" moduleId="org.eclipse.cdt.core.settings" name="Debug">
+        <externalSettings/>
+        <extensions>
+          <extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+          <extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+        </extensions>
+      </storageModule>
+      <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+        <configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291" name="Debug" parent="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug">
+          <folderInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291." name="/" resourcePath="">
+            <toolChain id="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.debug.462329838" name="MCU ARM GCC" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.debug">
+              <option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.type.706982539" name="Internal Toolchain Type" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.type" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.version.288924887" name="Internal Toolchain Version" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.version" value="7-2018-q2-update" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu.1073988192" name="Mcu" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu" value="STM32F469NIHx" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid.1571270724" name="CpuId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid" value="0" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid.1462088936" name="CpuCoreId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid" value="0" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.1692964530" name="Floating-point unit" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.value.fpv4-sp-d16" valueType="enumerated"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.1789621614" name="Floating-point ABI" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.value.hard" valueType="enumerated"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board.1691071603" name="Board" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board" value="genericBoard" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults.1008652457" name="Defaults" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults" value="com.st.stm32cube.ide.common.services.build.inputs.revA.1.0.6 || Debug || true || Executable || com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32 || STM32F469NIHx || 0 || 0 || arm-none-eabi- || ${gnu_tools_for_stm32_compiler_path} || ../../Core/Inc | ../../Drivers/CMSIS/Include | ../../TouchGFX/target | ../../Drivers/CMSIS/Device/ST/STM32F4xx/Include | ../../TouchGFX/App | ../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 | ../../TouchGFX/target/generated | ../../Drivers/BSP/Components/Common | ../../Middlewares/Third_Party/FreeRTOS/Source/include | ../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy | ../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F | ../../Drivers/BSP/STM32469I-Discovery | ../../Drivers/STM32F4xx_HAL_Driver/Inc ||  ||  || USE_HAL_DRIVER | STM32F469xx ||  ||  ||  ||  || ${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld} || true || NonSecure ||  || secure_nsclib.o ||  || None ||  ||  || " valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" value="false" valueType="boolean"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" value="true" valueType="boolean"/>
+              <option id="com.st.stm32cube.ide.mcu.debug.option.cpuclock.12012555" superClass="com.st.stm32cube.ide.mcu.debug.option.cpuclock" value="180" valueType="string"/>
+              <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform.1369289449" isAbstract="false" osList="all" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform"/>
+              <builder buildPath="${workspace_loc:/STM32F469I-DISCO-REV-AU1}/Debug" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder.1132458525" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.650711735" name="MCU GCC Assembler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.666566964" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g3" valueType="enumerated"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.definedsymbols.1167365880" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.definedsymbols" valueType="definedSymbols">
+                  <listOptionValue builtIn="false" value="DEBUG"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.459682850" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1847983586" name="MCU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.1774693180" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.925828807" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.value.os" valueType="enumerated"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols.1102406246" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
+                  <listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
+                  <listOptionValue builtIn="false" value="USE_BPP=16"/>
+                  <listOptionValue builtIn="false" value="STM32F469xx"/>
+                  <listOptionValue builtIn="false" value="DEBUG"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.898654131" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
+                  <listOptionValue builtIn="false" value="../../Core/Inc"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/App"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1036047372" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.584259652" name="MCU G++ Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.1578537529" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.1452145697" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.value.os" valueType="enumerated"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols.496359161" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
+                  <listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
+                  <listOptionValue builtIn="false" value="STM32F469xx"/>
+                  <listOptionValue builtIn="false" value="USE_BPP=16"/>
+                  <listOptionValue builtIn="false" value="DEBUG"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths.866852851" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
+                  <listOptionValue builtIn="false" value="../../Core/Inc"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/App"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.4365549957" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" valueType="stringList">
+                  <listOptionValue builtIn="false" value="-femit-class-debug-always"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1112311442" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1071469684" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script.525469482" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.387270243" name="MCU G++ Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script.262239035" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries.0109175191" name="Libraries (-l)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries" valueType="libs">
+                  <listOptionValue builtIn="false" value=":libtouchgfx-float-abi-hard.a"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories.0446552423" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories" valueType="libPaths">
+                  <listOptionValue builtIn="false" value="C:/git/STM32F469-dk/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/git/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/TouchGFXProjects/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/TouchGFXProjects/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/disan/GIT/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input.1690517566" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input">
+                  <additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+                  <additionalInput kind="additionalinput" paths="$(LIBS)"/>
+                </inputType>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver.112720624" name="MCU GCC Archiver" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size.1021209896" name="MCU Size" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile.1930886220" name="MCU Output Converter list file" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex.784557934" name="MCU Output Converter Hex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary.2036444560" name="MCU Output Converter Binary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog.112706189" name="MCU Output Converter Verilog" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec.1800298625" name="MCU Output Converter Motorola S-rec" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec.765135988" name="MCU Output Converter Motorola S-rec with symbols" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec"/>
+            </toolChain>
+          </folderInfo>
+        </configuration>
+      </storageModule>
+      <storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+    </cconfiguration>
+    <cconfiguration id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005">
+      <storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005" moduleId="org.eclipse.cdt.core.settings" name="Release">
+        <externalSettings/>
+        <extensions>
+          <extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+          <extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+          <extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+        </extensions>
+      </storageModule>
+      <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+        <configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005" name="Release" parent="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release">
+          <folderInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005." name="/" resourcePath="">
+            <toolChain id="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.release.1994443951" name="MCU ARM GCC" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.release">
+              <option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.type.1070928818" name="Internal Toolchain Type" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.type" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.option.internal.toolchain.version.641964570" name="Internal Toolchain Version" superClass="com.st.stm32cube.ide.mcu.option.internal.toolchain.version" value="7-2018-q2-update" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu.321322750" name="Mcu" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu" value="STM32F469NIHx" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid.1739227495" name="CpuId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_cpuid" value="0" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid.1613882270" name="CpuCoreId" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_coreid" value="0" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.348001976" name="Floating-point unit" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.fpu.value.fpv4-sp-d16" valueType="enumerated"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.151676201" name="Floating-point ABI" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.floatabi.value.hard" valueType="enumerated"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board.1378726694" name="Board" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board" value="genericBoard" valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults.1547637504" name="Defaults" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.defaults" value="com.st.stm32cube.ide.common.services.build.inputs.revA.1.0.6 || Release || false || Executable || com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.base.gnu-tools-for-stm32 || STM32F469NIHx || 0 || 0 || arm-none-eabi- || ${gnu_tools_for_stm32_compiler_path} || ../../Core/Inc | ../../Drivers/CMSIS/Include | ../../TouchGFX/target | ../../Drivers/CMSIS/Device/ST/STM32F4xx/Include | ../../TouchGFX/App | ../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 | ../../TouchGFX/target/generated | ../../Drivers/BSP/Components/Common | ../../Middlewares/Third_Party/FreeRTOS/Source/include | ../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy | ../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F | ../../Drivers/BSP/STM32469I-Discovery | ../../Drivers/STM32F4xx_HAL_Driver/Inc ||  ||  || USE_HAL_DRIVER | STM32F469xx ||  ||  ||  ||  || ${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld} || true || NonSecure ||  || secure_nsclib.o ||  || None ||  ||  || " valueType="string"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.convertbinary" value="false" valueType="boolean"/>
+              <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.converthex" value="true" valueType="boolean"/>
+              <option id="com.st.stm32cube.ide.mcu.debug.option.cpuclock.240469191" superClass="com.st.stm32cube.ide.mcu.debug.option.cpuclock" value="180" valueType="string"/>
+              <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform.148438337" isAbstract="false" osList="all" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform"/>
+              <builder buildPath="${workspace_loc:/STM32F469I-DISCO-REV-AU1}/Release" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder.186794699" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.546809183" name="MCU GCC Assembler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.197735926" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g0" valueType="enumerated"/>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.857362494" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1892273616" name="MCU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.1781937296" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.value.g0" valueType="enumerated"/>
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.599489623" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.value.os" valueType="enumerated"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols.569790826" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
+                  <listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
+                  <listOptionValue builtIn="false" value="USE_BPP=16"/>
+                  <listOptionValue builtIn="false" value="STM32F469xx"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.1345921988" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
+                  <listOptionValue builtIn="false" value="../../Core/Inc"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/App"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1751818057" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1548946496" name="MCU G++ Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.584413576" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.value.g0" valueType="enumerated"/>
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.1872327835" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.value.os" valueType="enumerated"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols.780269013" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
+                  <listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
+                  <listOptionValue builtIn="false" value="USE_BPP=16"/>
+                  <listOptionValue builtIn="false" value="STM32F469xx"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths.623536527" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
+                  <listOptionValue builtIn="false" value="../../Core/Inc"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/gui_generated/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/App"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/ST/touchgfx/framework/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/target/generated"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/Components/Common"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/gui/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/texts/include"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/images/include"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/include"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
+                  <listOptionValue builtIn="false" value="../../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/BSP/STM32469I-Discovery"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/fonts/include"/>
+                  <listOptionValue builtIn="false" value="../../Drivers/STM32F4xx_HAL_Driver/Inc"/>
+                  <listOptionValue builtIn="false" value="../../TouchGFX/generated/videos/include"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.2774206786" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" valueType="stringList">
+                  <listOptionValue builtIn="false" value="-femit-class-debug-always"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.376917327" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1929512438" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script.997537656" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.1191782340" name="MCU G++ Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker">
+                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script.530279426" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.script" value="${workspace_loc:/${ProjName}/STM32F469NIHX_FLASH.ld}" valueType="string"/>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries.6600641296" name="Libraries (-l)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.libraries" valueType="libs">
+                  <listOptionValue builtIn="false" value=":libtouchgfx-float-abi-hard.a"/>
+                </option>
+                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories.7485061840" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.option.directories" valueType="libPaths">
+                  <listOptionValue builtIn="false" value="C:/git/STM32F469-dk/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/git/stm32f469i_disco/STM32F469I-DISCO-REV-AU1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/TouchGFXProjects/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/TouchGFXProjects/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/MyApplication_1/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/disan/Documents/GIT/Dashboard/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/disan/GIT/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                  <listOptionValue builtIn="false" value="C:/Users/Christian/Documents/git/dashboard/Middlewares/ST/touchgfx/lib/core/cortex_m4f/gcc"/>
+                </option>
+                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input.129321398" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input">
+                  <additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+                  <additionalInput kind="additionalinput" paths="$(LIBS)"/>
+                </inputType>
+              </tool>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver.339128256" name="MCU GCC Archiver" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size.922199646" name="MCU Size" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile.183367632" name="MCU Output Converter list file" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex.1349177318" name="MCU Output Converter Hex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary.1446635427" name="MCU Output Converter Binary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog.1062307066" name="MCU Output Converter Verilog" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec.1957435828" name="MCU Output Converter Motorola S-rec" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec"/>
+              <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec.1951891889" name="MCU Output Converter Motorola S-rec with symbols" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec"/>
+            </toolChain>
+          </folderInfo>
+        </configuration>
+      </storageModule>
+      <storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+    </cconfiguration>
+  </storageModule>
+  <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+    <project id="STM32F469I-DISCO-REV-AU1.null.1960509173" name="STM32F469I-DISCO-REV-AU1"/>
+  </storageModule>
+  <storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+  <storageModule moduleId="scannerConfiguration">
+    <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+    <scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1847983586;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1036047372">
+      <autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
+    </scannerConfigBuildInfo>
+    <scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.1892273616;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.1751818057">
+      <autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
+    </scannerConfigBuildInfo>
+    <scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1630113291.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.584259652;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1112311442">
+      <autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
+    </scannerConfigBuildInfo>
+    <scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.release.132034005.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1548946496;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.376917327">
+      <autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
+    </scannerConfigBuildInfo>
+  </storageModule>
+  <storageModule moduleId="refreshScope" versionNumber="2">
+    <configuration configurationName="Debug">
+      <resource resourceType="PROJECT" workspacePath="/STM32F469I-DISCO-REV-AU1"/>
+    </configuration>
+    <configuration configurationName="Release">
+      <resource resourceType="PROJECT" workspacePath="/STM32F469I-DISCO-REV-AU1"/>
+    </configuration>
+  </storageModule>
+  <storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 </cproject>


### PR DESCRIPTION
Adds a test mode to allow for benchtop testing. This mode emulates CAN retrieval from the HAL to be as close as possible to the real deal.

Also updated all CAN-based data types to be 16-bit instead of 32-bit. This is to align with how the data comes in from CAN.